### PR TITLE
chore: update version to 1.0.4

### DIFF
--- a/mta.yaml
+++ b/mta.yaml
@@ -1,6 +1,6 @@
 _schema-version: 3.3.0
 ID: sales-order-backend
-version: 1.0.3
+version: 1.0.4
 description: Sales Order Management Backend App
 
 parameters:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sales-order-backend",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A simple CAP project.",
   "repository": "<Add your repository here>",
   "license": "UNLICENSED",


### PR DESCRIPTION
This release includes:

Removed filter restrictions to show empty option

PR https://github.com/lucasroseti/sales-order-backend/pull/1